### PR TITLE
Ensure atomic_tools can be imported from any folder

### DIFF
--- a/Atomic Physics/ZeemanSplitting.ipynb
+++ b/Atomic Physics/ZeemanSplitting.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Zeeman Splitting Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path().resolve().parent))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from atomic_tools import zeeman\n",
+    "print(zeeman.MU_B)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ A collection of utilities for atomic physics simulations. The toolkit is
 in an early stage and currently contains code for computing Zeeman energy
 splittings in Rubidium.
 
+## Installation
+
+To make the local ``atomic_tools`` package importable from anywhere in this
+repository install it in editable mode:
+
+```bash
+pip install -e .
+```
+
 ## Usage
 
 The main functionality lives in `atomic_tools.zeeman`. Example:

--- a/atomic_tools/__init__.py
+++ b/atomic_tools/__init__.py
@@ -1,0 +1,5 @@
+"""Atomic physics utility package."""
+
+from . import zeeman
+
+__all__ = ["zeeman"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bag-of-tools"
+version = "0.1.0"
+description = "Utilities for atomic physics simulations"
+authors = [{name = "BagOfTools Maintainers"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = ["numpy"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["atomic_tools"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,12 @@
+"""Test helpers for BagOfTools.
+
+Ensures the repository root is on ``sys.path`` so local imports
+like ``atomic_tools`` work regardless of the working directory.
+"""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_superradiance.ipynb
+++ b/tests/test_superradiance.ipynb
@@ -10,6 +10,15 @@
   },
   {
    "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path().resolve().parent))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "id": "7b12d242",
    "metadata": {},

--- a/tests/test_zeeman.ipynb
+++ b/tests/test_zeeman.ipynb
@@ -10,6 +10,15 @@
   },
   {
    "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path().resolve().parent))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "id": "0a21ffe0",
    "metadata": {},

--- a/tests/test_zeeman.py
+++ b/tests/test_zeeman.py
@@ -1,0 +1,27 @@
+import unittest
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from atomic_tools import zeeman
+
+
+class TestZeeman(unittest.TestCase):
+    def test_rb87_ground_gf(self):
+        g_f_F1 = zeeman.rb87_ground_gf(1)
+        g_f_F2 = zeeman.rb87_ground_gf(2)
+        self.assertAlmostEqual(g_f_F1, -0.5018, places=4)
+        self.assertAlmostEqual(g_f_F2, 0.4998, places=4)
+
+    def test_energy_frequency_consistency(self):
+        g_f = zeeman.rb87_ground_gf(2)
+        B = np.linspace(0, 1e-3, 5)
+        m_f = 1
+        energy = zeeman.zeeman_shift(B, m_f, g_f)
+        freq = zeeman.zeeman_frequency(B, m_f, g_f)
+        np.testing.assert_allclose(energy / zeeman.HPLANCK, freq)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add packaging config so `atomic_tools` can be installed as a package
- expose `zeeman` module and add path helpers in tests/notebooks
- document installation and include a proper unit test

## Testing
- `pip install -e .`
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_688fda34b01c832a885aab4ddef8e02d